### PR TITLE
[DOC] Add plantuml dependency, fix absolute paths

### DIFF
--- a/docs/3dmouse.rst
+++ b/docs/3dmouse.rst
@@ -5,10 +5,10 @@ Linux:
 
 .. uml::
 
-  !include /uml/3dmouse_linux.wsd
+  !include uml/3dmouse_linux.wsd
 
 Windows:
 
 .. uml::
 
-  !include /uml/3dmouse_win.wsd
+  !include uml/3dmouse_win.wsd

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,7 @@ html_theme_path = ['']
 htmlhelp_basename = '3dsoftviz_doc'
 
 #plantuml command
-plantuml = 'java -jar c:/Python27/plantuml.jar'
+plantuml = 'java -jar ../dependencies/plantuml/plantuml.jar'
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -4,29 +4,29 @@ Data
 Data:
 
    .. uml::
-      
-      !include /uml/data.wsd
+
+      !include uml/data.wsd
 
 Data1:
 
    .. uml::
-      
-      !include \uml\data1.wsd
+
+      !include uml/data1.wsd
 
 Data.Edge:
 
    .. uml::
-      
-      !include /uml/Data.Edge.wsd
+
+      !include uml/Data.Edge.wsd
 
 Data.Graph:
 
    .. uml::
-      
-      !include /uml/Data.Graph.wsd
+
+      !include uml/Data.Graph.wsd
 
 Data.Node:
 
    .. uml::
-      
-      !include /uml/Data.Node.wsd
+
+      !include uml/Data.Node.wsd

--- a/docs/git.rst
+++ b/docs/git.rst
@@ -4,15 +4,15 @@ GitLib
 GitLib a 3DSoftViz architektura:
 
    .. uml::
-      
-      !include /uml/git.wsd
 
-Diagram tried GitLib kniznice:	  
+      !include uml/git.wsd
+
+Diagram tried GitLib kniznice:
 
 .. image:: images/Class_Git.png
 
 Datovy diagram Git:
 
    .. uml::
-      
-      !include /uml/Datovy_model_git.wsd
+
+      !include uml/Datovy_model_git.wsd

--- a/docs/layout.rst
+++ b/docs/layout.rst
@@ -4,29 +4,29 @@ Layout
 Layout1:
 
    .. uml::
-      
-      !include /uml/Layout1.wsd
+
+      !include uml/Layout1.wsd
 
 Layout2:
 
    .. uml::
-      
-      !include /uml/Layout2.wsd
+
+      !include uml/Layout2.wsd
 
 Layout3:
 
    .. uml::
-      
-      !include /uml/Layout3.wsd
+
+      !include uml/Layout3.wsd
 
 Layout-Visitor:
 
    .. uml::
-      
-      !include /uml/Layout - Visitor.wsd
+
+      !include uml/Layout - Visitor.wsd
 
 Layout - complete:
 
    .. uml::
-      
-      !include /uml/Layout - komplet.wsd
+
+      !include uml/Layout - komplet.wsd

--- a/docs/leap.rst
+++ b/docs/leap.rst
@@ -1,9 +1,9 @@
 LeapSenzor
 ==========
 
-.. uml:: 
+.. uml::
 
-	!include /uml/LeapSenzor.wsd
+	!include uml/LeapSenzor.wsd
 
 LeapThread dedi of QThread
 - include Leap, LeapController

--- a/docs/network.rst
+++ b/docs/network.rst
@@ -4,11 +4,11 @@ Network
 Network:
 
    .. uml::
-      
-      !include /uml/Network1.wsd
+
+      !include uml/Network1.wsd
 
 Network (complete):
 
    .. uml::
-      
-      !include /uml/Network(complete).wsd
+
+      !include uml/Network(complete).wsd

--- a/docs/qosg.rst
+++ b/docs/qosg.rst
@@ -4,23 +4,23 @@ QOSG
 Nove pridane triedy:
 
    .. uml::
-      
-      !include /uml/QOSGnew.wsd
+
+      !include uml/QOSGnew.wsd
 
 CoreWindow:
 
    .. uml::
-      
-      !include /uml/QOSG - CoreWindow.wsd
+
+      !include uml/QOSG - CoreWindow.wsd
 
 QOSG:
 
    .. uml::
-      
-      !include /uml/QOSG2.wsd
+
+      !include uml/QOSG2.wsd
 
 QOSG complete:
 
    .. uml::
-      
-      !include /uml/QOSG(complet).wsd
+
+      !include uml/QOSG(complet).wsd

--- a/docs/uml.rst
+++ b/docs/uml.rst
@@ -9,7 +9,7 @@ Class Diagrams
 
 .. toctree::
    :maxdepth: 2
-   
+
    data
    layout
    leap
@@ -18,90 +18,90 @@ Class Diagrams
    viewer
    git
    3dmouse
-   
+
 AppCore:
 
    .. uml::
-      
-      !include \uml\AppCore.wsd
+
+      !include uml/AppCore.wsd
 
 ArucoModul:
 
    .. uml::
-      
-      !include /uml/ArucoModul.wsd
+
+      !include uml/ArucoModul.wsd
 
 Clustering:
 
    .. uml::
-      
-      !include /uml/Clustering.wsd
+
+      !include uml/Clustering.wsd
 
 Importer:
 
    .. uml::
-      
-      !include /uml/Importer.wsd
+
+      !include uml/Importer.wsd
 
 Kinect:
 
    .. uml::
-      
-      !include /uml/Kinect.wsd
+
+      !include uml/Kinect.wsd
 
 Lua:
 
    .. uml::
-      
-      !include /uml/Lua.wsd
+
+      !include uml/Lua.wsd
 
 Manager:
 
    .. uml::
-      
-      !include /uml/Manager.wsd
+
+      !include uml/Manager.wsd
 
 MathModul:
 
    .. uml::
-      
-      !include /uml/MathModule.wsd
+
+      !include uml/MathModule.wsd
 
 Model:
 
    .. uml::
-      
-      !include /uml/Model.wsd
+
+      !include uml/Model.wsd
 
 Noise:
 
    .. uml::
-      
-      !include /uml/Noise.wsd
+
+      !include uml/Noise.wsd
 
 OpenCV:
 
    .. uml::
-      
-      !include /uml/OpenCV.wsd
+
+      !include uml/OpenCV.wsd
 
 OsgQtBrowser:
 
    .. uml::
-      
-      !include /uml/OsgQtBrowser.wsd
+
+      !include uml/OsgQtBrowser.wsd
 
 QOpenCV:
 
    .. uml::
-      
-      !include /uml/QOpenCV.wsd
+
+      !include uml/QOpenCV.wsd
 
 Util:
 
    .. uml::
-      
-      !include /uml/Util.wsd
+
+      !include uml/Util.wsd
 
 Component diagrams
 ~~~~~~~~~~~~~~~~~~
@@ -109,8 +109,8 @@ Component diagrams
 Architektura 3dsoftviz:
 
    .. uml::
-      
-      !include /uml/Architektura_3DSoftViz.txt
+
+      !include uml/Architektura_3DSoftViz.txt
 
 Behavioral
 ----------
@@ -130,7 +130,7 @@ Sequence diagrams
 
 .. toctree::
    :maxdepth: 2
-   
+
    gitlua
 
 
@@ -139,7 +139,7 @@ Statechart diagrams
 
 Camera Movement:
 
-.. image:: /images/cameramove.png
+.. image:: images/cameramove.png
 
 
 
@@ -148,79 +148,76 @@ Object diagrams
 Graph structure layer0:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer0.wsd
+
+      !include uml/Graph.structure.layer0.wsd
 
 Graph structure layer1:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer1.wsd
+
+      !include uml/Graph.structure.layer1.wsd
 
 Graph structure layer2:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer2.wsd
-	  
+
+      !include uml/Graph.structure.layer2.wsd
+
 Graph structure layer3-Node:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer3.Node.wsd
+
+      !include uml/Graph.structure.layer3.Node.wsd
 
 Graph structure layer3-Edge:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer3.Edge.wsd
-	  
+
+      !include uml/Graph.structure.layer3.Edge.wsd
+
 Graph structure layer3-handsGroup:
 
    .. uml::
-      
-      !include /uml/Graph.structure.layer3.handsGroup.wsd
+
+      !include uml/Graph.structure.layer3.handsGroup.wsd
 
 LeapAR Adapter:
 
    .. uml::
-      
-      !include /uml/handsAR.adapter.wsd
+
+      !include uml/handsAR.adapter.wsd
 Api leap library:
 
    .. uml::
-      
-      !include /uml/handsAR.adapterLeap.wsd
-	  
+
+      !include uml/handsAR.adapterLeap.wsd
+
 Navrh modelu ruky layer0:
 
    .. uml::
-      
-      !include /uml/hand1.wsd
-	  
+
+      !include uml/hand1.wsd
+
 Navrh modelu ruky layer1:
 
    .. uml::
-      
-      !include /uml/hand2.wsd
-	  
+
+      !include uml/hand2.wsd
+
 Implementovany model ruky :
 
    .. uml::
-      
-      !include /uml/handModel.wsd	  
-	  
+
+      !include uml/handModel.wsd
+
 Volania pri update ruk v scene pri LeapAR:
 
    .. uml::
-      
-      !include /uml/handsAR.handsUpdate.wsd	  
-	  
+
+      !include uml/handsAR.handsUpdate.wsd
+
 Mapovanie ruk a update pozadia pri LeapAR :
 
    .. uml::
-      
-      !include /uml/handsAR.mappingAndBackground.wsd	  
-	  
 
-	  
+      !include uml/handsAR.mappingAndBackground.wsd

--- a/docs/uml/QOSGnew.wsd
+++ b/docs/uml/QOSGnew.wsd
@@ -1,6 +1,6 @@
 @startuml
 package QOSG{
-class AdapterWidget <|-right- ViewerQT
+AdapterWidget <|-right- ViewerQT
 ViewerQT -left-o CoreWindow
 CoreWindow -down- ProjectiveARCore
 ProjectiveARCore o-- ProjectiveARWindow

--- a/docs/uml/git.wsd
+++ b/docs/uml/git.wsd
@@ -3,43 +3,42 @@
 package Git {
 
 package GitLib {
-class GitEvolutionGraph -down- GitUtils
+GitEvolutionGraph -down- GitUtils
 GitEvolutionGraph *-down- GitVersion
 GitVersion *-down- GitFile
 GitFile -up- GitType
 GitFile *-down- GitFileDiffBlock
 GitFile -down- GitFileLoader
 GitFile *-down- GitFunction
-GitFunction *-- GitFunction 
+GitFunction *-- GitFunction
 GitFunction -down- GitFunctionType
 GitFileDiffBlock -down- GitFileLoader
 GitFileDiffBlock *-down- GitFileDiffBlockLine
 GitFileDiffBlockLine -down- GitFileLoader
-GitFileDiffBlockLine -up- GitType 
+GitFileDiffBlockLine -up- GitType
 GitVersion -down- GitFileLoader
 GitEvolutionGraph -down- GitEvolutionGraphManager
 GitEvolutionGraph -down- GitMetaData
 }
 
-class GitGraphUpdater -left- GitEvolutionGraph
-GitGraphUpdater -left- GitType 
+GitGraphUpdater -left- GitEvolutionGraph
+GitGraphUpdater -left- GitType
 GitGraphUpdater -left- GitFile
 GitGraphUpdater - GitVersion
 }
 
 package Data {
-class Node - GitGraphUpdater
-class Edge - GitGraphUpdater
-class Graph - GitGraphUpdater
+Node - GitGraphUpdater
+Edge - GitGraphUpdater
+Graph - GitGraphUpdater
 }
 
 package Manager {
-class Manager
 Manager - GitGraphUpdater
 }
 
 package Importer {
-class GraphOperations - GitGraphUpdater
+GraphOperations - GitGraphUpdater
 }
 
 @enduml

--- a/docs/viewer.rst
+++ b/docs/viewer.rst
@@ -4,23 +4,23 @@ Viewer
 Viewer1:
 
    .. uml::
-      
-      !include /uml/Vwr1.wsd
+
+      !include uml/Vwr1.wsd
 
 Viewer2:
 
    .. uml::
-      
-      !include /uml/Vwr2.wsd
+
+      !include uml/Vwr2.wsd
 
 Viewer3:
 
    .. uml::
-      
-      !include /uml/Vwr3.wsd
+
+      !include uml/Vwr3.wsd
 
 Viewer complete:
 
    .. uml::
-      
-      !include /uml/Vwr(complete).wsd
+
+      !include uml/Vwr(complete).wsd


### PR DESCRIPTION
Add new dependency Plantuml ver. 1.2017.18. Used by Sphinx to generate UML diagrams.
Fix absolute paths in conf.py and other rst files with ::uml: elements (mentioned in uml.rst).

Signed-off-by: pmarusin <peto.marusin@gmail.com>