### PR TITLE
[FIX] Fix QDebug library name

### DIFF
--- a/include/Util/CameraHelper.h
+++ b/include/Util/CameraHelper.h
@@ -3,7 +3,7 @@
 
 #include <osg/Camera>
 #include <QList>
-#include <qDebug>
+#include <QDebug>
 
 namespace Util {
 


### PR DESCRIPTION
Fix QDebug library name, according to official documentation http://doc.qt.io/qt-5/qdebug.html it should be **#import QDebug** not **#import qDebug**. 