### PR TITLE
using HTTPS instead of SSH protocol when initializing submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dependencies/libnoise"]
 	path = dependencies/libnoise
-	url = git@github.com:LuaDist/libnoise.git
+	url = https://github.com/LuaDist/libnoise.git
 [submodule "dependencies/luajit"]
 	path = dependencies/luajit
 	url = https://github.com/LuaDist/luajit.git
@@ -18,7 +18,7 @@
 	url = https://github.com/LuaDist/luametrics.git
 [submodule "dependencies/aruco"]
 	path = dependencies/aruco
-	url = git@github.com:LuaDist/aruco.git
+	url = https://github.com/LuaDist/aruco.git
 [submodule "dependencies/luafilesystem"]
 	path = dependencies/luafilesystem
 	url = https://github.com/LuaDist/luafilesystem.git
@@ -27,67 +27,67 @@
 	url = https://github.com/LuaDist/lua.git
 [submodule "dependencies/osgModeling"]
 	path = dependencies/osgModeling
-	url = git@github.com:kapecp/osgmodeling.git
+	url = https://github.com/kapecp/osgmodeling.git
 [submodule "dependencies/igloo"]
 	path = dependencies/igloo
-	url = git@github.com:kapecp/igloo.git
+	url = https://github.com/kapecp/igloo.git
 [submodule "dependencies/lualogging"]
 	path = dependencies/lualogging
 	url = https://github.com/LuaDist/lualogging.git
 [submodule "dependencies/easyloggingpp"]
 	path = dependencies/easyloggingpp
-	url = git@github.com:easylogging/easyloggingpp.git
+	url = https://github.com/easylogging/easyloggingpp.git
 [submodule "dependencies/parserlib"]
 	path = dependencies/parserlib
-	url = git@github.com:axilmar/parserlib.git
+	url = https://github.com/axilmar/parserlib.git
 [submodule "dependencies/StackTracePlus"]
 	path = dependencies/StackTracePlus
-	url = git@github.com:LuaDist/StackTracePlus.git
+	url = https://github.com/LuaDist/StackTracePlus.git
 [submodule "dependencies/luasocket"]
 	path = dependencies/luasocket
-	url = git@github.com:LuaDist/luasocket.git
+	url = https://github.com/LuaDist/luasocket.git
 [submodule "dependencies/mobdebug"]
 	path = dependencies/mobdebug
-	url = git@github.com:LuaDist/mobdebug.git
+	url = https://github.com/LuaDist/mobdebug.git
 [submodule "dependencies/luacov"]
 	path = dependencies/luacov
-	url = git@github.com:LuaDist/luacov.git
+	url = https://github.com/LuaDist/luacov.git
 [submodule "dependencies/luacheck"]
 	path = dependencies/luacheck
-	url = git@github.com:LuaDist/luacheck.git
+	url = https://github.com/LuaDist/luacheck.git
 [submodule "dependencies/lua_cliargs"]
 	path = dependencies/lua_cliargs
-	url = git@github.com:LuaDist/lua_cliargs.git
+	url = https://github.com/LuaDist/lua_cliargs.git
 [submodule "dependencies/luasystem"]
 	path = dependencies/luasystem
-	url = git@github.com:LuaDist/luasystem.git
+	url = https://github.com/LuaDist/luasystem.git
 [submodule "dependencies/dkjson"]
 	path = dependencies/dkjson
-	url = git@github.com:LuaDist/dkjson.git
+	url = https://github.com/LuaDist/dkjson.git
 [submodule "dependencies/say"]
 	path = dependencies/say
-	url = git@github.com:LuaDist/say.git
+	url = https://github.com/LuaDist/say.git
 [submodule "dependencies/luassert"]
 	path = dependencies/luassert
-	url = git@github.com:LuaDist/luassert.git
+	url = https://github.com/LuaDist/luassert.git
 [submodule "dependencies/lua-term"]
 	path = dependencies/lua-term
-	url = git@github.com:LuaDist/lua-term.git
+	url = https://github.com/LuaDist/lua-term.git
 [submodule "dependencies/penlight"]
 	path = dependencies/penlight
-	url = git@github.com:LuaDist/penlight.git
+	url = https://github.com/LuaDist/penlight.git
 [submodule "dependencies/mediator_lua"]
 	path = dependencies/mediator_lua
-	url = git@github.com:LuaDist/mediator_lua.git
+	url = https://github.com/LuaDist/mediator_lua.git
 [submodule "dependencies/busted"]
 	path = dependencies/busted
-	url = git@github.com:LuaDist/busted.git
+	url = https://github.com/LuaDist/busted.git
 [submodule "dependencies/leathers"]
 	path = dependencies/leathers
-	url = git@github.com:kapecp/leathers.git
+	url = https://github.com/kapecp/leathers.git
 [submodule "dependencies/luacomments"]
 	path = dependencies/luacomments
 	url = https://github.com/LuaDist/luacomments.git
 [submodule "dependencies/osgQt"]
 	path = dependencies/osgQt
-	url = git@github.com:openscenegraph/osgQt.git
+	url = https://github.com/openscenegraph/osgQt.git

--- a/src/Data/OsgNode.cpp
+++ b/src/Data/OsgNode.cpp
@@ -4,7 +4,7 @@
 #include "Data/Cluster.h"
 
 #include "Util/ApplicationConfig.h"
-
+#include "Util/CameraHelper.h"
 #include <osg/Geometry>
 #include <osg/ShapeDrawable>
 #include <osg/Depth>


### PR DESCRIPTION
change is needed in .gitmodules file, so docker and vagrant VM's don't need SSH key to clone and build 3dsoftviz